### PR TITLE
Update .gitignore for macOS and Xcode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
-# macOS системные файлы
+# macOS
 .DS_Store
 
-# Xcode временные и пользовательские файлы
+# Xcode
 build/
 DerivedData/
+xcuserdata/
+*.xccheckout
+*.xcscmblueprint
 *.xcuserstate
-*.xcuserdata/
+*.xcworkspace
+*.xcconfig
+
+# Swift Package Manager
+.swiftpm/
+.build/


### PR DESCRIPTION
Add additional macOS and Xcode related files and directories to the
.gitignore to prevent committing user-specific and temporary files.
Include Swift Package Manager build artifacts to keep the repository
clean from generated files.