### PR TITLE
chore/update-error-handling

### DIFF
--- a/QuickRate/QuickRate/Modules/CurrencyConverter/CurrencyConverterViewModel.swift
+++ b/QuickRate/QuickRate/Modules/CurrencyConverter/CurrencyConverterViewModel.swift
@@ -63,12 +63,12 @@ final class CurrencyConverterViewModel: CurrencyConverterViewModelProtocol {
         state.send(.init(isLoading: true))
         Task {
             do {
-                currencyOptions = try await currencyExchangeService.fetchCurrencies()
+                currencyOptions = try await currencyExchangeService.fetchCurrencies().sorted()
                 fromCurrency = currencyOptions.first ?? "BYN"
                 toCurrency = currencyOptions.dropFirst().first ?? "USD"
                 state.send(CurrencyConverterState(currencies: currencyOptions, isLoading: false))
-            } catch let error as QuickRateError {
-                updateErrorMessage(message: error.errorDescription)
+            } catch {
+                updateErrorMessage(message: error.localizedDescription)
             }
         }
     }
@@ -89,8 +89,8 @@ final class CurrencyConverterViewModel: CurrencyConverterViewModelProtocol {
             do {
                 let response = try await currencyExchangeService.fetchExchangeRate(model)
                 updateConvertedValue(value: response.amount)
-            } catch let error as QuickRateError {
-                updateErrorMessage(message: error.errorDescription)
+            } catch {
+                updateErrorMessage(message: error.localizedDescription)
             }
         }
     }

--- a/QuickRate/QuickRate/Network/Base/EndPoint.swift
+++ b/QuickRate/QuickRate/Network/Base/EndPoint.swift
@@ -35,7 +35,7 @@ extension EndPoint {
         nil
     }
 
-    func urlRequest() throws -> URLRequest {
+    func urlRequest() throws(NetworkError) -> URLRequest {
         if let url = url {
             var request = URLRequest(url: url)
             request.httpMethod = httpMethod.rawValue
@@ -43,7 +43,7 @@ extension EndPoint {
             request.allHTTPHeaderFields = headers
             return request
         } else {
-            throw QuickRateError(error: "invalid_url", errorDescription: "Wrong url")
+            throw NetworkError.invalidURL
         }
     }
 }

--- a/QuickRate/QuickRate/Network/Base/NetworkError.swift
+++ b/QuickRate/QuickRate/Network/Base/NetworkError.swift
@@ -1,0 +1,31 @@
+//
+//  NetworkError.swift
+//  QuickRate
+//
+//  Created by Nikolay Gilvey on 1.06.25.
+//
+
+import Foundation
+
+enum NetworkError: Error, LocalizedError {
+    case invalidURL
+    case requestFailed(underlying: Error)
+    case serverError(ServerError)
+    case decodingFailed
+    case unknown
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "🧁 Bad recipe: The URL is invalid."
+        case .requestFailed(let error):
+            return "🥧 Oven broke down: Network request failed. (\(error.localizedDescription))"
+        case .serverError(let error):
+            return "🍰 Burnt on delivery: Server responded with code: \(error.errorDescription)."
+        case .decodingFailed:
+            return "🍪 Crumbled recipe: Failed to decode the response."
+        case .unknown:
+            return "🍩 Mystery muffin: Something unexpected happened."
+        }
+    }
+}

--- a/QuickRate/QuickRate/Network/Base/ServerError.swift
+++ b/QuickRate/QuickRate/Network/Base/ServerError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct QuickRateError: Error, Decodable {
+struct ServerError: Error, Decodable {
     let error: String
     let errorDescription: String
     
@@ -17,6 +17,6 @@ struct QuickRateError: Error, Decodable {
     }
 }
 
-extension QuickRateError {
-    static let `default` = QuickRateError(error: "parse_error", errorDescription: "Oops, smth went wrong")
+extension ServerError {
+    static let `default` = ServerError(error: "parse_error", errorDescription: "Oops, smth went wrong")
 }

--- a/QuickRate/QuickRate/Network/CurrencyExchange/CurrencyExchangeNetworkService/CurrencyExchangeNetworkService.swift
+++ b/QuickRate/QuickRate/Network/CurrencyExchange/CurrencyExchangeNetworkService/CurrencyExchangeNetworkService.swift
@@ -9,17 +9,17 @@ import Foundation
 
 protocol CurrencyExchangeNetworkProtocol {
     
-    func fetchExchangeRate(_ model: ExchangeRequestModel) async throws -> ExchangeResponse
-    func fetchCurrencies() async throws -> [String]
+    func fetchExchangeRate(_ model: ExchangeRequestModel) async throws(NetworkError) -> ExchangeResponse
+    func fetchCurrencies() async throws(NetworkError) -> [String]
 }
 
 final class CurrencyExchangeNetworkService: NetworkService, CurrencyExchangeNetworkProtocol {
     
-    func fetchExchangeRate(_ model: ExchangeRequestModel) async throws -> ExchangeResponse {
+    func fetchExchangeRate(_ model: ExchangeRequestModel) async throws(NetworkError) -> ExchangeResponse {
         return try await client.performRequest(CurrencyExchangeProvider.Request.exchange(model: model))
     }
     
-    func fetchCurrencies() async throws -> [String] {
+    func fetchCurrencies() async throws(NetworkError) -> [String] {
         return try await client.performRequest(CurrencyExchangeProvider.Request.getCurrencies)
     }
 }

--- a/QuickRate/QuickRate/Network/CurrencyExchange/Provider/CurrencyExchangeProvider.swift
+++ b/QuickRate/QuickRate/Network/CurrencyExchange/Provider/CurrencyExchangeProvider.swift
@@ -8,13 +8,6 @@
 import Foundation
 
 enum CurrencyExchangeProvider {
-    enum Path {
-        static let baseURL = "http://api.evp.lt/currency/commercial/"
-        static let latest = "latest"
-        static let exchange = "exchange"
-        static let currencies = "currencies"
-    }
-    
     enum Request {
         case exchange(model: ExchangeRequestModel)
         case getCurrencies
@@ -26,11 +19,11 @@ extension CurrencyExchangeProvider.Request: EndPoint {
         var path = ""
         switch self {
         case .exchange(let model):
-            path = "\(CurrencyExchangeProvider.Path.exchange)/\(model.amount)-\(model.fromCurrency)/\(model.toCurrency)/\(CurrencyExchangeProvider.Path.latest)"
+            path = "exchange/\(model.amount)-\(model.fromCurrency)/\(model.toCurrency)/latest"
             
         case .getCurrencies:
-            path = CurrencyExchangeProvider.Path.currencies
+            path = "currencies"
         }
-        return URL(string: CurrencyExchangeProvider.Path.baseURL + path)
+        return URL(string: "http://api.evp.lt/currency/commercial/" + path)
     }
 }


### PR DESCRIPTION
### Description

- Introduce unified `NetworkError` enum and `ServerError` struct for standardized and descriptive error handling in network layers.
- Refactor `APIService` and `CurrencyExchangeNetworkService` to throw `NetworkError` explicitly, wrapping URLSession, HTTP response, and decoding errors.
- Simplify URL construction by removing redundant `Path` enum constants and inlining URL strings.
- Update `EndPoint` to throw specific `NetworkError` instead of generic errors for better clarity.
- Sort fetched currency options alphabetically for consistent UI display.
- Improve error handling by replacing specific error catches with generic ones to show accurate localized error messages.