### PR TITLE
feat(currency-converter): update UI on currency switch action

### DIFF
--- a/QuickRate/QuickRate/Modules/CurrencyConverter/Model/CurrencyConverterState.swift
+++ b/QuickRate/QuickRate/Modules/CurrencyConverter/Model/CurrencyConverterState.swift
@@ -12,4 +12,5 @@ struct CurrencyConverterState {
     var errorMessage: String?
     var currencies: [String]?
     var isLoading: Bool = false
+    var switchedCurrencies: (String, String)?
 }

--- a/QuickRate/QuickRate/Modules/CurrencyConverter/View/CurrencyConverterViewController.swift
+++ b/QuickRate/QuickRate/Modules/CurrencyConverter/View/CurrencyConverterViewController.swift
@@ -196,6 +196,11 @@ private extension CurrencyConverterViewController {
                     self.setupCurrencyMenus(with: currencies)
                     self.isCurrencyMenuSetup = true
                 }
+                
+                if let (fromCurrency, toCurrency) = state.switchedCurrencies {
+                    fromCurrencyButton.setTitle(fromCurrency, for: .normal)
+                    toCurrencyButton.setTitle(toCurrency, for: .normal)
+                }
             }
             .store(in: &cancellables)
     }
@@ -207,8 +212,6 @@ private extension CurrencyConverterViewController {
     @objc
     func switchCurrencies() {
         viewModel.send(.switchCurrencies(currentAmount: amountTextField.text ?? ""))
-        fromCurrencyButton.setTitle(viewModel.fromCurrency, for: .normal)
-        toCurrencyButton.setTitle(viewModel.toCurrency, for: .normal)
     }
     
     @objc

--- a/QuickRate/QuickRate/Modules/CurrencyConverter/ViewModel/CurrencyConverterViewModel.swift
+++ b/QuickRate/QuickRate/Modules/CurrencyConverter/ViewModel/CurrencyConverterViewModel.swift
@@ -10,8 +10,6 @@ import Combine
 
 protocol CurrencyConverterViewModelProtocol: AnyObject {
     var state: PassthroughSubject<CurrencyConverterState, Never> { get }
-    var fromCurrency: String { get }
-    var toCurrency: String { get }
     
     func send(_ event: CurrencyConverterEvent)
 }
@@ -45,6 +43,8 @@ final class CurrencyConverterViewModel: CurrencyConverterViewModelProtocol {
         case .switchCurrencies(let currentAmount):
             swap(&fromCurrency, &toCurrency)
             getExchangeRate(for: currentAmount)
+            let newState = CurrencyConverterState(switchedCurrencies: (fromCurrency, toCurrency))
+            state.send(newState)
         case .selectCurrency(let type, let value, let currentAmount):
             switch type {
             case .from:


### PR DESCRIPTION
Emit switchedCurrencies state when currencies are swapped in the
view model to keep the UI in sync. Update the view controller to
observe this state and update the currency button titles accordingly.

Remove redundant fromCurrency and toCurrency properties from the
protocol to simplify state management and rely on the new state
property for UI updates. This ensures a single source of truth for
currency selection and improves consistency across the app.